### PR TITLE
fix: update cache-control for uploaded assets

### DIFF
--- a/main.js
+++ b/main.js
@@ -9,7 +9,7 @@ async function deploy() {
 
     try {
         await exec.exec(`aws s3 sync ${localSource} s3://${s3Bucket} --delete --cache-control 'public, no-store, max-age=0'`, [])
-        await exec.exec(`aws s3 cp s3://${s3Bucket}/static s3://${s3Bucket}/static --metadata-directive REPLACE --cache-control 'public, max-age=31536000, immutable' --acl public-read`, []) 
+        await exec.exec(`aws s3 cp s3://${s3Bucket}/static s3://${s3Bucket}/static --metadata-directive REPLACE --cache-control 'public, max-age=31536000, immutable'`, []) 
     } catch(error) {
         core.setFailed('Error with upload')
     }

--- a/main.js
+++ b/main.js
@@ -5,17 +5,14 @@ const path = require('path')
 async function deploy() {
     const folder = core.getInput('folder')
     const s3Bucket = core.getInput('s3-bucket-name')
-
     const localSource = path.resolve(folder)
-    return new Promise((resolve, reject) => {
-        try {
-            const cmd = `aws s3 sync ${localSource} s3://${s3Bucket} --delete`
-            // execute
-            exec.exec(cmd, []).then(resolve('Success')).catch(err => reject(err.message))
-        } catch (error) {
-            core.setFailed('Error with upload')
-        }  
-    })
+
+    try {
+        await exec.exec(`aws s3 sync ${localSource} s3://${s3Bucket} --delete --cache-control 'public, no-store, max-age=0'`, [])
+        await exec.exec(`aws s3 cp s3://${s3Bucket}/static s3://${s3Bucket}/static --metadata-directive REPLACE --cache-control 'public, max-age=31536000, immutable' --acl public-read`, []) 
+    } catch(error) {
+        core.setFailed('Error with upload')
+    }
 }
 
 async function runDeploy() {


### PR DESCRIPTION
**Note**: This will definitely need to be tested. Unfortunately, I don't have the details to do this on my side.

# Description

The intention is to set the associated Cache-Control header for assets when uploading to S3. Previously no cache-control strategy was being applied. I believe this is why we are running into cache issues on VV, as the browser is applying defaults where it shouldn't e.g. with our `service-worker.js` (https://stackoverflow.com/a/41714580)

With the new strategy:
- Assets are not cached by default e.g. index.html, server-worker.js & manifest.json
- Files in /static are considered immutable with a max-age of 31536000 since they are fingerprinted

Please let me know if there is a better way to do this with the AWS CLI. I'm not familiar with it.